### PR TITLE
Relax rails dependencies for 4.2.x

### DIFF
--- a/easy_api_doc.gemspec
+++ b/easy_api_doc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", [">= 4.0.0", '< 4.2']
+  s.add_dependency "rails", [">= 4.0.0", '< 4.3']
   s.add_dependency "github-markup", "~> 0.7.2"
   s.add_dependency "redcarpet"
 


### PR DESCRIPTION
Appears no changes required to the gem to support 4.2.x.
